### PR TITLE
Replace ssh-rsa keys with ssh-ed25519

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -45,7 +45,7 @@ terraform destroy -var yc_folder=<folder_id> -var yc_token=<yc_token> -var user=
     ```bash
     terraform init
     ```
-1. В файле [tank/main.tf](tank/main.tf) укажите путь к публичному и приватному ssh ключам (Дефолтные значения `~/.ssh/id_rsa.pub` и `~/.ssh/id_rsa`)
+1. В файле [tank/main.tf](tank/main.tf) укажите путь к публичному и приватному ssh ключам (Дефолтные значения `~/.ssh/id_ed25519.pub` и `~/.ssh/id_ed25519`)
 1. Развернуть и запустить приложение. 
     
     **Внимание: Танк необходимо создавать после основного окружения, так как оно необходимо для генерации конфигов.**

--- a/terraform/app/todo-service.tf
+++ b/terraform/app/todo-service.tf
@@ -30,7 +30,7 @@ resource "yandex_compute_instance_group" "todo_instances" {
     }
     service_account_id = yandex_iam_service_account.todo_node_sa.id
     metadata = {
-      ssh-keys = "${var.user}:${file("~/.ssh/id_rsa.pub")}"
+      ssh-keys = "${var.user}:${file("~/.ssh/id_ed25519.pub")}"
       docker-container-declaration = templatefile("${path.module}/files/spec.yaml", {
         docker_image   = "cr.yandex/${data.yandex_container_registry.todo_registry.id}/todo-demo:v1"
         database_uri   = "postgresql://${local.dbuser}:${local.dbpassword}@:1/${local.dbname}"

--- a/terraform/tank/main.tf
+++ b/terraform/tank/main.tf
@@ -1,6 +1,6 @@
 locals {
-  public_ssh_key = "${file("~/.ssh/id_rsa.pub")}"
-  private_ssh_key = "${file("~/.ssh/id_rsa")}"
+  public_ssh_key = "${file("~/.ssh/id_ed25519.pub")}"
+  private_ssh_key = "${file("~/.ssh/id_ed25519")}"
 }
 
 provider "yandex" {


### PR DESCRIPTION
`ssh-rsa` keys are deprecated in the latest OpenSSH versions, so we are replacing mentions of them in Yandex Cloud docs with `ssh-ed25519`. This pull request is changing the demo in line with the docs.